### PR TITLE
Feature csv utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,3 +17,4 @@ enable_testing()
 add_subdirectory(test)
 
 add_test(main.test lodging)
+add_test(DatabaseFile.test test/DatabaseFile.test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,6 @@ add_test(main.test lodging)
 
 ## Unit tests
 add_test(DatabaseFile.test test/DatabaseFile.test)
-add_test(DatabaseFile.data.csv.test test/DatabaseFile.test data/bos2021ModC.csv)
-add_test(DatabaseFile.data.tsv.test test/DatabaseFile.test data/bos2021ModC.tsv "\t")
-add_test(DatabaseFile.data.psv.test test/DatabaseFile.test data/bos2021ModC.dat "|")
+add_test(DatabaseFile.data.csv.test test/DatabaseFile.test test/data/bos2021ModC.csv)
+add_test(DatabaseFile.data.tsv.test test/DatabaseFile.test test/data/bos2021ModC.tsv "\t")
+add_test(DatabaseFile.data.psv.test test/DatabaseFile.test test/data/bos2021ModC.dat "|")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD 14)
 add_executable(
     lodging
     src/main.cpp
+    src/utils/io/DatabaseFile.cpp src/utils/io/DatabaseFile.h
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,11 @@ add_executable(
 enable_testing()
 add_subdirectory(test)
 
+## Black box tests
 add_test(main.test lodging)
+
+## Unit tests
 add_test(DatabaseFile.test test/DatabaseFile.test)
+add_test(DatabaseFile.data.csv.test test/DatabaseFile.test data/bos2021ModC.csv)
+add_test(DatabaseFile.data.tsv.test test/DatabaseFile.test data/bos2021ModC.tsv "\t")
+add_test(DatabaseFile.data.psv.test test/DatabaseFile.test data/bos2021ModC.dat "|")

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -1,11 +1,6 @@
 #include "DatabaseFile.h"
 
 namespace utils {
-    DatabaseFile::DatabaseFile() {
-        this->path = "";
-        this->delim = ",";
-    }
-
     DatabaseFile::DatabaseFile(const std::string &delim) {
         this->path = "";
         this->delim = delim;

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -1,4 +1,4 @@
-#include <iomanip>
+#include <sstream>
 #include "DatabaseFile.h"
 
 namespace utils {
@@ -50,7 +50,7 @@ namespace utils {
                 for (size_t i = 0; i < keys.size(); i++) {
                     record.emplace(keys[i], values[i]);
                 }
-                data.push_back(record);
+                this->data.emplace_back(record);
             }
         }
 
@@ -71,12 +71,20 @@ namespace utils {
     }
 
     bool DatabaseFile::write() {
+        if (this->data.empty()) return false;
+
         std::string buffer;
         std::vector<std::string> keys;
 
         this->file.open(this->path, std::ios::out);
         if (!this->file.is_open()) return false;  // TODO: Throw error here for "unable to write database"
 
+        // Write header
+        for (size_t i = 0; i < keys.size(); i++) {
+            file << keys[i] << (i == keys.size() ? "\n" : this->delim);
+        }
+
+        // Write records
         for (const auto &record : data) {
             size_t pair_count = 0;
             for (const auto& pair : record) {

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -50,6 +50,7 @@ namespace utils {
                 for (size_t i = 0; i < keys.size(); i++) {
                     record.emplace(keys[i], values[i]);
                 }
+                data.push_back(record);
             }
         }
 

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -14,7 +14,7 @@ namespace utils {
 
 
     bool DatabaseFile::open() {
-        return false;
+        return false;  // TODO: Implement
     }
 
     bool DatabaseFile::open(const std::string &path) {
@@ -31,7 +31,7 @@ namespace utils {
     }
 
     bool DatabaseFile::write() {
-        return false;
+        return false;  // TODO: Implement
     }
 
     bool DatabaseFile::write(std::vector<std::map<std::string, std::string>> &data) {

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -75,14 +75,14 @@ namespace utils {
         if (this->data.empty()) return false;
 
         std::string buffer;
-        std::vector<std::string> keys;
 
         this->file.open(this->path, std::ios::out);
         if (!this->file.is_open()) return false;  // TODO: Throw error here for "unable to write database"
 
         // Write header
+        std::vector<std::string> keys = this->keys();
         for (size_t i = 0; i < keys.size(); i++) {
-            file << keys[i] << (i == keys.size() ? "\n" : this->delim);
+            file << keys[i] << (i + 1 == keys.size() ? "\n" : this->delim);
         }
 
         // Write records

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -54,6 +54,7 @@ namespace utils {
             }
         }
 
+        this->file.close();
         return true;
     }
 
@@ -93,6 +94,7 @@ namespace utils {
             }
         }
 
+        this->file.close();
         return true;
     }
 

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -1,0 +1,70 @@
+#include "DatabaseFile.h"
+
+namespace utils {
+    DatabaseFile::DatabaseFile() {
+        this->path = "";
+        this->delim = ",";
+    }
+
+    DatabaseFile::DatabaseFile(const std::string &delim) {
+        this->path = "";
+        this->delim = delim;
+    }
+
+    DatabaseFile::DatabaseFile(const std::string &path, const std::string &delim) {
+        this->path = path;
+        this->delim = delim;
+    }
+
+
+    bool DatabaseFile::open() {
+        return false;
+    }
+
+    bool DatabaseFile::open(const std::string &path) {
+        this->path = path;
+        return this->open();
+    }
+
+    bool DatabaseFile::write(std::vector<std::map<std::string, std::string>> &data) {
+        return false;
+    }
+
+    bool DatabaseFile::write(const std::string &path, std::vector<std::map<std::string, std::string>> &data) {
+        this->path = path;
+        return this->write(data);
+    }
+
+
+    size_t DatabaseFile::size() {
+        return this->data.size();
+    }
+
+    bool DatabaseFile::empty() {
+        return this->data.empty();
+    }
+
+    std::vector<std::string> DatabaseFile::keys() {
+        std::vector<std::string> result;
+        if (!this->data.empty()) {
+            for (
+                const auto &pair : this->data.at(0)) {
+                result.push_back(pair.first);
+            }
+        }
+        return result;
+    }
+
+    std::map<std::string, std::string> DatabaseFile::get(size_t index) {
+        return this->data.at(index);
+    }
+
+
+    std::string DatabaseFile::get_delim() {
+        return this->delim;
+    }
+
+    void DatabaseFile::set_delim(const std::string &val) {
+        this->delim = val;
+    }
+} // utils

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -1,9 +1,9 @@
 #include "DatabaseFile.h"
 
 namespace utils {
-    DatabaseFile::DatabaseFile(const std::string &delim) {
+    DatabaseFile::DatabaseFile() {
         this->path = "";
-        this->delim = delim;
+        this->delim = ",";
     }
 
     DatabaseFile::DatabaseFile(const std::string &path, const std::string &delim) {
@@ -22,13 +22,27 @@ namespace utils {
         return this->open();
     }
 
-    bool DatabaseFile::write(std::vector<std::map<std::string, std::string>> &data) {
+    void DatabaseFile::load(std::vector<std::map<std::string, std::string>> &data) {
+        this->data = data;
+    }
+
+    void DatabaseFile::unload(std::vector<std::map<std::string, std::string>> &data) {
+        data = this->data;
+    }
+
+    bool DatabaseFile::write() {
         return false;
+    }
+
+    bool DatabaseFile::write(std::vector<std::map<std::string, std::string>> &data) {
+        this->data = data;
+        return this->write();
     }
 
     bool DatabaseFile::write(const std::string &path, std::vector<std::map<std::string, std::string>> &data) {
         this->path = path;
-        return this->write(data);
+        this->data = data;
+        return this->write();
     }
 
 
@@ -52,7 +66,7 @@ namespace utils {
     }
 
     std::map<std::string, std::string> DatabaseFile::get(size_t index) {
-        return this->data.at(index);
+        return this->data[index];
     }
 
 
@@ -62,5 +76,10 @@ namespace utils {
 
     void DatabaseFile::set_delim(const std::string &val) {
         this->delim = val;
+    }
+
+
+    std::map<std::string, std::string> DatabaseFile::operator[](size_t index) {
+        return this->get(index);
     }
 } // utils

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -76,6 +76,14 @@ namespace utils {
         this->file.open(this->path, std::ios::out);
         if (!this->file.is_open()) return false;  // TODO: Throw error here for "unable to write database"
 
+        for (const auto &record : data) {
+            size_t pair_count = 0;
+            for (const auto& pair : record) {
+                pair_count++;
+                file << pair.second << (record.size() == pair_count ? "\n" : this->delim);
+            }
+        }
+
         return true;
     }
 

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -9,6 +9,7 @@ namespace utils {
     DatabaseFile::DatabaseFile(const std::string &path, const std::string &delim) {
         this->path = path;
         this->delim = delim;
+        this->open(this->path);
     }
 
 

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -3,11 +3,20 @@
 
 namespace utils {
     std::vector<std::string> DatabaseFile::tokenize(const std::string &str) {
+        bool quoted_field = false;
         std::vector<std::string> tokens;
         size_t token_start = 0, token_end = 0;
 
         while (token_end != std::string::npos) {
-            token_end = str.find(this->delim, token_start);
+            if (str[token_start] == QUOTE) quoted_field = true;
+            if (quoted_field) {
+                while (quoted_field) {
+                    token_end = str.find(this->delim, token_end + this->delim.length());
+                    if (str[token_end - 1] == QUOTE && str[token_end - 2] != '\\') quoted_field = false;
+                }
+            } else {
+                token_end = str.find(this->delim, token_start);
+            }
             tokens.push_back(str.substr(token_start, token_end - token_start));
             token_start = token_end + this->delim.length();
         }

--- a/src/utils/io/DatabaseFile.cpp
+++ b/src/utils/io/DatabaseFile.cpp
@@ -1,6 +1,21 @@
+#include <iomanip>
 #include "DatabaseFile.h"
 
 namespace utils {
+    std::vector<std::string> DatabaseFile::tokenize(const std::string &str) {
+        std::vector<std::string> tokens;
+        size_t token_start = 0, token_end = 0;
+
+        while (token_end != std::string::npos) {
+            token_end = str.find(this->delim, token_start);
+            tokens.push_back(str.substr(token_start, token_end - token_start));
+            token_start = token_end + this->delim.length();
+        }
+
+        return tokens;
+    }
+
+
     DatabaseFile::DatabaseFile() {
         this->path = "";
         this->delim = ",";
@@ -14,7 +29,31 @@ namespace utils {
 
 
     bool DatabaseFile::open() {
-        return false;  // TODO: Implement
+        this->file.open(this->path, std::ios::in);
+        if (!this->file.is_open()) return false;  // TODO: Throw error here for "unable to read database"
+
+        std::string buffer;
+
+        // Read keys
+        std::getline(this->file, buffer);
+        if (buffer.empty()) return false;  // TODO: Throw error here for "corrupted database"
+        std::vector<std::string> keys = this->tokenize(buffer);
+
+        // Read values
+        std::vector<std::string> values;
+        while (std::getline(this->file, buffer)) {
+            if (!buffer.empty()) {
+                values = this->tokenize(buffer);
+                if (keys.size() != values.size()) return false;  // TODO: Throw error here for "corrupted database"
+
+                std::map<std::string, std::string> record;
+                for (size_t i = 0; i < keys.size(); i++) {
+                    record.emplace(keys[i], values[i]);
+                }
+            }
+        }
+
+        return true;
     }
 
     bool DatabaseFile::open(const std::string &path) {
@@ -31,7 +70,13 @@ namespace utils {
     }
 
     bool DatabaseFile::write() {
-        return false;  // TODO: Implement
+        std::string buffer;
+        std::vector<std::string> keys;
+
+        this->file.open(this->path, std::ios::out);
+        if (!this->file.is_open()) return false;  // TODO: Throw error here for "unable to write database"
+
+        return true;
     }
 
     bool DatabaseFile::write(std::vector<std::map<std::string, std::string>> &data) {

--- a/src/utils/io/DatabaseFile.h
+++ b/src/utils/io/DatabaseFile.h
@@ -27,11 +27,14 @@ namespace utils {
         std::fstream file;
 
       public:
-        explicit DatabaseFile(const std::string &delim = ",");
+        DatabaseFile();
         explicit DatabaseFile(const std::string &path, const std::string &delim = ",");
 
         bool open();
         bool open(const std::string &path);
+        void load(std::vector<std::map<std::string, std::string>> &data);
+        void unload(std::vector<std::map<std::string, std::string>> &data);
+        bool write();
         bool write(std::vector<std::map<std::string, std::string>> &data);
         bool write(const std::string &path, std::vector<std::map<std::string, std::string>> &data);
 
@@ -42,6 +45,8 @@ namespace utils {
         std::map<std::string, std::string> get(size_t index);
         std::string get_delim();
         void set_delim(const std::string &val);
+
+        std::map<std::string, std::string> operator[](size_t index);
     };
 
 } // utils

--- a/src/utils/io/DatabaseFile.h
+++ b/src/utils/io/DatabaseFile.h
@@ -26,6 +26,9 @@ namespace utils {
         std::vector<std::map<std::string, std::string>> data;
         std::fstream file;
 
+      protected:
+        std::vector<std::string> tokenize(const std::string &str);
+
       public:
         DatabaseFile();
         explicit DatabaseFile(const std::string &path, const std::string &delim = ",");

--- a/src/utils/io/DatabaseFile.h
+++ b/src/utils/io/DatabaseFile.h
@@ -27,7 +27,6 @@ namespace utils {
         std::fstream file;
 
       public:
-        DatabaseFile();
         explicit DatabaseFile(const std::string &delim = ",");
         explicit DatabaseFile(const std::string &path, const std::string &delim = ",");
 

--- a/src/utils/io/DatabaseFile.h
+++ b/src/utils/io/DatabaseFile.h
@@ -1,0 +1,50 @@
+#ifndef RMIT2022C_EEET2482_LODGING_APP_SRC_UTILS_IO_DATABASEFILE_H_
+#define RMIT2022C_EEET2482_LODGING_APP_SRC_UTILS_IO_DATABASEFILE_H_
+
+#include <fstream>
+#include <map>
+#include <vector>
+
+namespace utils {
+
+    /**
+     *
+     * <p>
+     * Utility class for saving a Vector of HashMaps into a delimiter-separated database text file and vice-versa. Uses
+     * comma <code><strong>","</strong><code> as the default delimiter. Saved file always has first line containing keys
+     * and subsequent lines containing values.
+     * </p>
+     *
+     * <p>
+     * Can skip through blank lines when reading database file.
+     * </p>
+     *
+     */
+    class DatabaseFile {
+      private:
+        std::string path, delim;
+        std::vector<std::map<std::string, std::string>> data;
+        std::fstream file;
+
+      public:
+        DatabaseFile();
+        explicit DatabaseFile(const std::string &delim = ",");
+        explicit DatabaseFile(const std::string &path, const std::string &delim = ",");
+
+        bool open();
+        bool open(const std::string &path);
+        bool write(std::vector<std::map<std::string, std::string>> &data);
+        bool write(const std::string &path, std::vector<std::map<std::string, std::string>> &data);
+
+        size_t size();
+        bool empty();
+        std::vector<std::string> keys();
+
+        std::map<std::string, std::string> get(size_t index);
+        std::string get_delim();
+        void set_delim(const std::string &val);
+    };
+
+} // utils
+
+#endif //RMIT2022C_EEET2482_LODGING_APP_SRC_UTILS_IO_DATABASEFILE_H_

--- a/src/utils/io/DatabaseFile.h
+++ b/src/utils/io/DatabaseFile.h
@@ -5,6 +5,8 @@
 #include <map>
 #include <vector>
 
+#define QUOTE '\"'
+
 namespace utils {
 
     /**
@@ -16,7 +18,12 @@ namespace utils {
      * </p>
      *
      * <p>
-     * Can skip through blank lines when reading database file.
+     * Notes:
+     * <ul>
+     *  <li>Can skip through blank lines when reading database file.</li>
+     *  <li>Not greedy. I.e. does not discard consecutive delimiters but treats them as empty fields.</li>
+     *  <li>Quoted field always use quote <code><strong>"</strong></code> character.</li>
+     * </ul>
      * </p>
      *
      */

--- a/src/utils/io/DatabaseFile.h
+++ b/src/utils/io/DatabaseFile.h
@@ -21,7 +21,7 @@ namespace utils {
      * Notes:
      * <ul>
      *  <li>Can skip through blank lines when reading database file.</li>
-     *  <li>Not greedy. I.e. does not discard consecutive delimiters but treats them as empty fields.</li>
+     *  <li>Not greedy, e.g. does not discard consecutive delimiters but treats them as empty fields.</li>
      *  <li>Quoted field always use quote <code><strong>"</strong></code> character.</li>
      * </ul>
      * </p>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,3 +4,9 @@ add_dependencies(
     all-tests
     lodging
 )
+
+# Copy test files into build folder
+add_custom_command(TARGET all-tests PRE_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory
+                   ${CMAKE_SOURCE_DIR}/test/data/ ${CMAKE_BINARY_DIR}/test/data/
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,11 +2,21 @@ add_custom_target(all-tests)
 
 add_dependencies(
     all-tests
+
+    DatabaseFile.test
     lodging
 )
 
-# Copy test files into build folder
-add_custom_command(TARGET all-tests PRE_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy_directory
-                   ${CMAKE_SOURCE_DIR}/test/data/ ${CMAKE_BINARY_DIR}/test/data/
+## Prebuild task: Copy test files into build folder
+add_custom_command(
+    TARGET all-tests PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_SOURCE_DIR}/test/data/ ${CMAKE_BINARY_DIR}/test/data/
+)
+
+## Test targets
+add_executable(
+    DatabaseFile.test EXCLUDE_FROM_ALL
+    utils/io/DatabaseFile.test.cpp
+    ../src/utils/io/DatabaseFile.cpp ../src/utils/io/DatabaseFile.h
 )

--- a/test/data/README.md
+++ b/test/data/README.md
@@ -1,0 +1,11 @@
+# Test data
+
+
+## 1. bos2021ModC
+
+Source: [Business operations survey: 2021 – The transition to low emissions economy – CSV](https://www.stats.govt.nz/assets/Uploads/Business-operations-survey/Business-operations-survey-2021/Download-data/bos2021ModC.csv). Courtesy: Statistics New Zealand (https://www.stats.govt.nz/)
+
+Files:
+* bos2021ModC.csv (comma separated, UTF-8 text, 100 entries)
+* bos2021ModC.tsv (tab separated, UTF-8 text, 100 entries)
+* bos2021ModC.dat (pipe separated, UTF-8 text, 100 entries)

--- a/test/data/bos2021ModC.csv
+++ b/test/data/bos2021ModC.csv
@@ -1,0 +1,100 @@
+description,industry,level,size,line_code,value
+Awareness of climate change: Very aware,total,0,619 employees,C0300.01,13080
+Awareness of climate change: Very aware,total,0,2049 employees,C0300.01,3348
+Awareness of climate change: Very aware,total,0,5099 employees,C0300.01,1089
+Awareness of climate change: Very aware,total,0,100+ employees,C0300.01,1023
+Awareness of climate change: Very aware,"Agriculture, forestry, & fishing",1,total,C0300.01,2364
+Awareness of climate change: Very aware,Agriculture,2,total,C0300.01,1683
+Awareness of climate change: Very aware,Commercial fishing,2,total,C0300.01,27
+Awareness of climate change: Very aware,Forestry & logging,2,total,C0300.01,126
+Awareness of climate change: Very aware,"Agriculture, forestry, & fishing support services",2,total,C0300.01,528
+Awareness of climate change: Very aware,Mining,1,total,C0300.01,72
+Awareness of climate change: Very aware,Manufacturing,1,total,C0300.01,1971
+Awareness of climate change: Very aware,"Food, beverage, & tobacco",2,total,C0300.01,588
+Awareness of climate change: Very aware,"Textile, clothing, footwear, & leather",2,total,C0300.01,96
+Awareness of climate change: Very aware,Wood & paper product,2,total,C0300.01,156
+Awareness of climate change: Very aware,"Printing, publishing, & recorded media",2,total,C0300.01,72
+Awareness of climate change: Very aware,"Petroleum, coal, chemical, & associated product",2,total,C0300.01,189
+Awareness of climate change: Very aware,Non-metallic mineral product,2,total,C0300.01,108
+Awareness of climate change: Very aware,Metal product,2,total,C0300.01,246
+Awareness of climate change: Very aware,Transport and industrial machinery & equipment,2,total,C0300.01,285
+Awareness of climate change: Very aware,Other machinery & equipment,2,total,C0300.01,117
+Awareness of climate change: Very aware,Other manufacturing,2,total,C0300.01,111
+Awareness of climate change: Very aware,"Electricity, gas, water, & waste services",1,total,C0300.01,114
+Awareness of climate change: Very aware,Construction,1,total,C0300.01,2685
+Awareness of climate change: Very aware,Wholesale trade,1,total,C0300.01,1287
+Awareness of climate change: Very aware,Machinery & equipment wholesaling,2,total,C0300.01,264
+Awareness of climate change: Very aware,Other wholesale trade,2,total,C0300.01,1023
+Awareness of climate change: Very aware,Retail trade,1,total,C0300.01,1848
+Awareness of climate change: Very aware,Accommodation & food services,1,total,C0300.01,1887
+Awareness of climate change: Very aware,"Transport, postal, & warehousing",1,total,C0300.01,603
+Awareness of climate change: Very aware,Information media & telecommunications,1,total,C0300.01,195
+Awareness of climate change: Very aware,Publishing,2,total,C0300.01,72
+Awareness of climate change: Very aware,Motion picture,2,total,C0300.01,60
+Awareness of climate change: Very aware,Telecommunications,2,total,C0300.01,60
+Awareness of climate change: Very aware,Financial & insurance services,1,total,C0300.01,312
+Awareness of climate change: Very aware,Finance,2,total,C0300.01,96
+Awareness of climate change: Very aware,Insurance,2,total,C0300.01,15
+Awareness of climate change: Very aware,Auxiliary,2,total,C0300.01,204
+Awareness of climate change: Very aware,"Rental, hiring, & real estate services",1,total,C0300.01,387
+Awareness of climate change: Very aware,"Professional, scientific, & technical services",1,total,C0300.01,1992
+Awareness of climate change: Very aware,Computer systems design,2,total,C0300.01,408
+Awareness of climate change: Very aware,Other professional scientific,2,total,C0300.01,1587
+Awareness of climate change: Very aware,Administrative & support services,1,total,C0300.01,762
+Awareness of climate change: Very aware,Education & training,1,total,C0300.01,423
+Awareness of climate change: Very aware,Health care & social assistance,1,total,C0300.01,879
+Awareness of climate change: Very aware,Arts & recreation services,1,total,C0300.01,198
+Awareness of climate change: Very aware,Other services,1,total,C0300.01,555
+Awareness of climate change: Very aware,total,0,total,C0300.01,18540
+Awareness of climate change: Somewhat aware,total,0,619 employees,C0300.02,15810
+Awareness of climate change: Somewhat aware,total,0,2049 employees,C0300.02,3732
+Awareness of climate change: Somewhat aware,total,0,5099 employees,C0300.02,1089
+Awareness of climate change: Somewhat aware,total,0,100+ employees,C0300.02,786
+Awareness of climate change: Somewhat aware,"Agriculture, forestry, & fishing",1,total,C0300.02,1269
+Awareness of climate change: Somewhat aware,Agriculture,2,total,C0300.02,735
+Awareness of climate change: Somewhat aware,Commercial fishing,2,total,C0300.02,21
+Awareness of climate change: Somewhat aware,Forestry & logging,2,total,C0300.02,126
+Awareness of climate change: Somewhat aware,"Agriculture, forestry, & fishing support services",2,total,C0300.02,387
+Awareness of climate change: Somewhat aware,Mining,1,total,C0300.02,33
+Awareness of climate change: Somewhat aware,Manufacturing,1,total,C0300.02,2586
+Awareness of climate change: Somewhat aware,"Food, beverage, & tobacco",2,total,C0300.02,459
+Awareness of climate change: Somewhat aware,"Textile, clothing, footwear, & leather",2,total,C0300.02,129
+Awareness of climate change: Somewhat aware,Wood & paper product,2,total,C0300.02,294
+Awareness of climate change: Somewhat aware,"Printing, publishing, & recorded media",2,total,C0300.02,102
+Awareness of climate change: Somewhat aware,"Petroleum, coal, chemical, & associated product",2,total,C0300.02,204
+Awareness of climate change: Somewhat aware,Non-metallic mineral product,2,total,C0300.02,90
+Awareness of climate change: Somewhat aware,Metal product,2,total,C0300.02,588
+Awareness of climate change: Somewhat aware,Transport and industrial machinery & equipment,2,total,C0300.02,456
+Awareness of climate change: Somewhat aware,Other machinery & equipment,2,total,C0300.02,105
+Awareness of climate change: Somewhat aware,Other manufacturing,2,total,C0300.02,159
+Awareness of climate change: Somewhat aware,"Electricity, gas, water, & waste services",1,total,C0300.02,66
+Awareness of climate change: Somewhat aware,Construction,1,total,C0300.02,2955
+Awareness of climate change: Somewhat aware,Wholesale trade,1,total,C0300.02,1491
+Awareness of climate change: Somewhat aware,Machinery & equipment wholesaling,2,total,C0300.02,609
+Awareness of climate change: Somewhat aware,Other wholesale trade,2,total,C0300.02,879
+Awareness of climate change: Somewhat aware,Retail trade,1,total,C0300.02,2145
+Awareness of climate change: Somewhat aware,Accommodation & food services,1,total,C0300.02,3129
+Awareness of climate change: Somewhat aware,"Transport, postal, & warehousing",1,total,C0300.02,921
+Awareness of climate change: Somewhat aware,Information media & telecommunications,1,total,C0300.02,183
+Awareness of climate change: Somewhat aware,Publishing,2,total,C0300.02,72
+Awareness of climate change: Somewhat aware,Motion picture,2,total,C0300.02,51
+Awareness of climate change: Somewhat aware,Telecommunications,2,total,C0300.02,57
+Awareness of climate change: Somewhat aware,Financial & insurance services,1,total,C0300.02,246
+Awareness of climate change: Somewhat aware,Finance,2,total,C0300.02,90
+Awareness of climate change: Somewhat aware,Insurance,2,total,C0300.02,18
+Awareness of climate change: Somewhat aware,Auxiliary,2,total,C0300.02,141
+Awareness of climate change: Somewhat aware,"Rental, hiring, & real estate services",1,total,C0300.02,423
+Awareness of climate change: Somewhat aware,"Professional, scientific, & technical services",1,total,C0300.02,2250
+Awareness of climate change: Somewhat aware,Computer systems design,2,total,C0300.02,423
+Awareness of climate change: Somewhat aware,Other professional scientific,2,total,C0300.02,1833
+Awareness of climate change: Somewhat aware,Administrative & support services,1,total,C0300.02,804
+Awareness of climate change: Somewhat aware,Education & training,1,total,C0300.02,513
+Awareness of climate change: Somewhat aware,Health care & social assistance,1,total,C0300.02,1485
+Awareness of climate change: Somewhat aware,Arts & recreation services,1,total,C0300.02,231
+Awareness of climate change: Somewhat aware,Other services,1,total,C0300.02,678
+Awareness of climate change: Somewhat aware,total,0,total,C0300.02,21417
+Awareness of climate change: Not aware,total,0,619 employees,C0300.03,2955
+Awareness of climate change: Not aware,total,0,2049 employees,C0300.03,519
+Awareness of climate change: Not aware,total,0,5099 employees,C0300.03,105
+Awareness of climate change: Not aware,total,0,100+ employees,C0300.03,42
+Awareness of climate change: Not aware,"Agriculture, forestry, & fishing",1,total,C0300.03,54

--- a/test/data/bos2021ModC.dat
+++ b/test/data/bos2021ModC.dat
@@ -1,0 +1,100 @@
+description|industry|level|size|line_code|value
+Awareness of climate change: Very aware|total|0|619 employees|C0300.01|13080
+Awareness of climate change: Very aware|total|0|2049 employees|C0300.01|3348
+Awareness of climate change: Very aware|total|0|5099 employees|C0300.01|1089
+Awareness of climate change: Very aware|total|0|100+ employees|C0300.01|1023
+Awareness of climate change: Very aware|"Agriculture, forestry, & fishing"|1|total|C0300.01|2364
+Awareness of climate change: Very aware|Agriculture|2|total|C0300.01|1683
+Awareness of climate change: Very aware|Commercial fishing|2|total|C0300.01|27
+Awareness of climate change: Very aware|Forestry & logging|2|total|C0300.01|126
+Awareness of climate change: Very aware|"Agriculture, forestry, & fishing support services"|2|total|C0300.01|528
+Awareness of climate change: Very aware|Mining|1|total|C0300.01|72
+Awareness of climate change: Very aware|Manufacturing|1|total|C0300.01|1971
+Awareness of climate change: Very aware|"Food, beverage, & tobacco"|2|total|C0300.01|588
+Awareness of climate change: Very aware|"Textile, clothing, footwear, & leather"|2|total|C0300.01|96
+Awareness of climate change: Very aware|Wood & paper product|2|total|C0300.01|156
+Awareness of climate change: Very aware|"Printing, publishing, & recorded media"|2|total|C0300.01|72
+Awareness of climate change: Very aware|"Petroleum, coal, chemical, & associated product"|2|total|C0300.01|189
+Awareness of climate change: Very aware|Non-metallic mineral product|2|total|C0300.01|108
+Awareness of climate change: Very aware|Metal product|2|total|C0300.01|246
+Awareness of climate change: Very aware|Transport and industrial machinery & equipment|2|total|C0300.01|285
+Awareness of climate change: Very aware|Other machinery & equipment|2|total|C0300.01|117
+Awareness of climate change: Very aware|Other manufacturing|2|total|C0300.01|111
+Awareness of climate change: Very aware|"Electricity, gas, water, & waste services"|1|total|C0300.01|114
+Awareness of climate change: Very aware|Construction|1|total|C0300.01|2685
+Awareness of climate change: Very aware|Wholesale trade|1|total|C0300.01|1287
+Awareness of climate change: Very aware|Machinery & equipment wholesaling|2|total|C0300.01|264
+Awareness of climate change: Very aware|Other wholesale trade|2|total|C0300.01|1023
+Awareness of climate change: Very aware|Retail trade|1|total|C0300.01|1848
+Awareness of climate change: Very aware|Accommodation & food services|1|total|C0300.01|1887
+Awareness of climate change: Very aware|"Transport, postal, & warehousing"|1|total|C0300.01|603
+Awareness of climate change: Very aware|Information media & telecommunications|1|total|C0300.01|195
+Awareness of climate change: Very aware|Publishing|2|total|C0300.01|72
+Awareness of climate change: Very aware|Motion picture|2|total|C0300.01|60
+Awareness of climate change: Very aware|Telecommunications|2|total|C0300.01|60
+Awareness of climate change: Very aware|Financial & insurance services|1|total|C0300.01|312
+Awareness of climate change: Very aware|Finance|2|total|C0300.01|96
+Awareness of climate change: Very aware|Insurance|2|total|C0300.01|15
+Awareness of climate change: Very aware|Auxiliary|2|total|C0300.01|204
+Awareness of climate change: Very aware|"Rental, hiring, & real estate services"|1|total|C0300.01|387
+Awareness of climate change: Very aware|"Professional, scientific, & technical services"|1|total|C0300.01|1992
+Awareness of climate change: Very aware|Computer systems design|2|total|C0300.01|408
+Awareness of climate change: Very aware|Other professional scientific|2|total|C0300.01|1587
+Awareness of climate change: Very aware|Administrative & support services|1|total|C0300.01|762
+Awareness of climate change: Very aware|Education & training|1|total|C0300.01|423
+Awareness of climate change: Very aware|Health care & social assistance|1|total|C0300.01|879
+Awareness of climate change: Very aware|Arts & recreation services|1|total|C0300.01|198
+Awareness of climate change: Very aware|Other services|1|total|C0300.01|555
+Awareness of climate change: Very aware|total|0|total|C0300.01|18540
+Awareness of climate change: Somewhat aware|total|0|619 employees|C0300.02|15810
+Awareness of climate change: Somewhat aware|total|0|2049 employees|C0300.02|3732
+Awareness of climate change: Somewhat aware|total|0|5099 employees|C0300.02|1089
+Awareness of climate change: Somewhat aware|total|0|100+ employees|C0300.02|786
+Awareness of climate change: Somewhat aware|"Agriculture, forestry, & fishing"|1|total|C0300.02|1269
+Awareness of climate change: Somewhat aware|Agriculture|2|total|C0300.02|735
+Awareness of climate change: Somewhat aware|Commercial fishing|2|total|C0300.02|21
+Awareness of climate change: Somewhat aware|Forestry & logging|2|total|C0300.02|126
+Awareness of climate change: Somewhat aware|"Agriculture, forestry, & fishing support services"|2|total|C0300.02|387
+Awareness of climate change: Somewhat aware|Mining|1|total|C0300.02|33
+Awareness of climate change: Somewhat aware|Manufacturing|1|total|C0300.02|2586
+Awareness of climate change: Somewhat aware|"Food, beverage, & tobacco"|2|total|C0300.02|459
+Awareness of climate change: Somewhat aware|"Textile, clothing, footwear, & leather"|2|total|C0300.02|129
+Awareness of climate change: Somewhat aware|Wood & paper product|2|total|C0300.02|294
+Awareness of climate change: Somewhat aware|"Printing, publishing, & recorded media"|2|total|C0300.02|102
+Awareness of climate change: Somewhat aware|"Petroleum, coal, chemical, & associated product"|2|total|C0300.02|204
+Awareness of climate change: Somewhat aware|Non-metallic mineral product|2|total|C0300.02|90
+Awareness of climate change: Somewhat aware|Metal product|2|total|C0300.02|588
+Awareness of climate change: Somewhat aware|Transport and industrial machinery & equipment|2|total|C0300.02|456
+Awareness of climate change: Somewhat aware|Other machinery & equipment|2|total|C0300.02|105
+Awareness of climate change: Somewhat aware|Other manufacturing|2|total|C0300.02|159
+Awareness of climate change: Somewhat aware|"Electricity, gas, water, & waste services"|1|total|C0300.02|66
+Awareness of climate change: Somewhat aware|Construction|1|total|C0300.02|2955
+Awareness of climate change: Somewhat aware|Wholesale trade|1|total|C0300.02|1491
+Awareness of climate change: Somewhat aware|Machinery & equipment wholesaling|2|total|C0300.02|609
+Awareness of climate change: Somewhat aware|Other wholesale trade|2|total|C0300.02|879
+Awareness of climate change: Somewhat aware|Retail trade|1|total|C0300.02|2145
+Awareness of climate change: Somewhat aware|Accommodation & food services|1|total|C0300.02|3129
+Awareness of climate change: Somewhat aware|"Transport, postal, & warehousing"|1|total|C0300.02|921
+Awareness of climate change: Somewhat aware|Information media & telecommunications|1|total|C0300.02|183
+Awareness of climate change: Somewhat aware|Publishing|2|total|C0300.02|72
+Awareness of climate change: Somewhat aware|Motion picture|2|total|C0300.02|51
+Awareness of climate change: Somewhat aware|Telecommunications|2|total|C0300.02|57
+Awareness of climate change: Somewhat aware|Financial & insurance services|1|total|C0300.02|246
+Awareness of climate change: Somewhat aware|Finance|2|total|C0300.02|90
+Awareness of climate change: Somewhat aware|Insurance|2|total|C0300.02|18
+Awareness of climate change: Somewhat aware|Auxiliary|2|total|C0300.02|141
+Awareness of climate change: Somewhat aware|"Rental, hiring, & real estate services"|1|total|C0300.02|423
+Awareness of climate change: Somewhat aware|"Professional, scientific, & technical services"|1|total|C0300.02|2250
+Awareness of climate change: Somewhat aware|Computer systems design|2|total|C0300.02|423
+Awareness of climate change: Somewhat aware|Other professional scientific|2|total|C0300.02|1833
+Awareness of climate change: Somewhat aware|Administrative & support services|1|total|C0300.02|804
+Awareness of climate change: Somewhat aware|Education & training|1|total|C0300.02|513
+Awareness of climate change: Somewhat aware|Health care & social assistance|1|total|C0300.02|1485
+Awareness of climate change: Somewhat aware|Arts & recreation services|1|total|C0300.02|231
+Awareness of climate change: Somewhat aware|Other services|1|total|C0300.02|678
+Awareness of climate change: Somewhat aware|total|0|total|C0300.02|21417
+Awareness of climate change: Not aware|total|0|619 employees|C0300.03|2955
+Awareness of climate change: Not aware|total|0|2049 employees|C0300.03|519
+Awareness of climate change: Not aware|total|0|5099 employees|C0300.03|105
+Awareness of climate change: Not aware|total|0|100+ employees|C0300.03|42
+Awareness of climate change: Not aware|"Agriculture, forestry, & fishing"|1|total|C0300.03|54

--- a/test/data/bos2021ModC.tsv
+++ b/test/data/bos2021ModC.tsv
@@ -1,0 +1,100 @@
+description	industry	level	size	line_code	value
+Awareness of climate change: Very aware	total	0	619 employees	C0300.01	13080
+Awareness of climate change: Very aware	total	0	2049 employees	C0300.01	3348
+Awareness of climate change: Very aware	total	0	5099 employees	C0300.01	1089
+Awareness of climate change: Very aware	total	0	100+ employees	C0300.01	1023
+Awareness of climate change: Very aware	"Agriculture, forestry, & fishing"	1	total	C0300.01	2364
+Awareness of climate change: Very aware	Agriculture	2	total	C0300.01	1683
+Awareness of climate change: Very aware	Commercial fishing	2	total	C0300.01	27
+Awareness of climate change: Very aware	Forestry & logging	2	total	C0300.01	126
+Awareness of climate change: Very aware	"Agriculture, forestry, & fishing support services"	2	total	C0300.01	528
+Awareness of climate change: Very aware	Mining	1	total	C0300.01	72
+Awareness of climate change: Very aware	Manufacturing	1	total	C0300.01	1971
+Awareness of climate change: Very aware	"Food, beverage, & tobacco"	2	total	C0300.01	588
+Awareness of climate change: Very aware	"Textile, clothing, footwear, & leather"	2	total	C0300.01	96
+Awareness of climate change: Very aware	Wood & paper product	2	total	C0300.01	156
+Awareness of climate change: Very aware	"Printing, publishing, & recorded media"	2	total	C0300.01	72
+Awareness of climate change: Very aware	"Petroleum, coal, chemical, & associated product"	2	total	C0300.01	189
+Awareness of climate change: Very aware	Non-metallic mineral product	2	total	C0300.01	108
+Awareness of climate change: Very aware	Metal product	2	total	C0300.01	246
+Awareness of climate change: Very aware	Transport and industrial machinery & equipment	2	total	C0300.01	285
+Awareness of climate change: Very aware	Other machinery & equipment	2	total	C0300.01	117
+Awareness of climate change: Very aware	Other manufacturing	2	total	C0300.01	111
+Awareness of climate change: Very aware	"Electricity, gas, water, & waste services"	1	total	C0300.01	114
+Awareness of climate change: Very aware	Construction	1	total	C0300.01	2685
+Awareness of climate change: Very aware	Wholesale trade	1	total	C0300.01	1287
+Awareness of climate change: Very aware	Machinery & equipment wholesaling	2	total	C0300.01	264
+Awareness of climate change: Very aware	Other wholesale trade	2	total	C0300.01	1023
+Awareness of climate change: Very aware	Retail trade	1	total	C0300.01	1848
+Awareness of climate change: Very aware	Accommodation & food services	1	total	C0300.01	1887
+Awareness of climate change: Very aware	"Transport, postal, & warehousing"	1	total	C0300.01	603
+Awareness of climate change: Very aware	Information media & telecommunications	1	total	C0300.01	195
+Awareness of climate change: Very aware	Publishing	2	total	C0300.01	72
+Awareness of climate change: Very aware	Motion picture	2	total	C0300.01	60
+Awareness of climate change: Very aware	Telecommunications	2	total	C0300.01	60
+Awareness of climate change: Very aware	Financial & insurance services	1	total	C0300.01	312
+Awareness of climate change: Very aware	Finance	2	total	C0300.01	96
+Awareness of climate change: Very aware	Insurance	2	total	C0300.01	15
+Awareness of climate change: Very aware	Auxiliary	2	total	C0300.01	204
+Awareness of climate change: Very aware	"Rental, hiring, & real estate services"	1	total	C0300.01	387
+Awareness of climate change: Very aware	"Professional, scientific, & technical services"	1	total	C0300.01	1992
+Awareness of climate change: Very aware	Computer systems design	2	total	C0300.01	408
+Awareness of climate change: Very aware	Other professional scientific	2	total	C0300.01	1587
+Awareness of climate change: Very aware	Administrative & support services	1	total	C0300.01	762
+Awareness of climate change: Very aware	Education & training	1	total	C0300.01	423
+Awareness of climate change: Very aware	Health care & social assistance	1	total	C0300.01	879
+Awareness of climate change: Very aware	Arts & recreation services	1	total	C0300.01	198
+Awareness of climate change: Very aware	Other services	1	total	C0300.01	555
+Awareness of climate change: Very aware	total	0	total	C0300.01	18540
+Awareness of climate change: Somewhat aware	total	0	619 employees	C0300.02	15810
+Awareness of climate change: Somewhat aware	total	0	2049 employees	C0300.02	3732
+Awareness of climate change: Somewhat aware	total	0	5099 employees	C0300.02	1089
+Awareness of climate change: Somewhat aware	total	0	100+ employees	C0300.02	786
+Awareness of climate change: Somewhat aware	"Agriculture, forestry, & fishing"	1	total	C0300.02	1269
+Awareness of climate change: Somewhat aware	Agriculture	2	total	C0300.02	735
+Awareness of climate change: Somewhat aware	Commercial fishing	2	total	C0300.02	21
+Awareness of climate change: Somewhat aware	Forestry & logging	2	total	C0300.02	126
+Awareness of climate change: Somewhat aware	"Agriculture, forestry, & fishing support services"	2	total	C0300.02	387
+Awareness of climate change: Somewhat aware	Mining	1	total	C0300.02	33
+Awareness of climate change: Somewhat aware	Manufacturing	1	total	C0300.02	2586
+Awareness of climate change: Somewhat aware	"Food, beverage, & tobacco"	2	total	C0300.02	459
+Awareness of climate change: Somewhat aware	"Textile, clothing, footwear, & leather"	2	total	C0300.02	129
+Awareness of climate change: Somewhat aware	Wood & paper product	2	total	C0300.02	294
+Awareness of climate change: Somewhat aware	"Printing, publishing, & recorded media"	2	total	C0300.02	102
+Awareness of climate change: Somewhat aware	"Petroleum, coal, chemical, & associated product"	2	total	C0300.02	204
+Awareness of climate change: Somewhat aware	Non-metallic mineral product	2	total	C0300.02	90
+Awareness of climate change: Somewhat aware	Metal product	2	total	C0300.02	588
+Awareness of climate change: Somewhat aware	Transport and industrial machinery & equipment	2	total	C0300.02	456
+Awareness of climate change: Somewhat aware	Other machinery & equipment	2	total	C0300.02	105
+Awareness of climate change: Somewhat aware	Other manufacturing	2	total	C0300.02	159
+Awareness of climate change: Somewhat aware	"Electricity, gas, water, & waste services"	1	total	C0300.02	66
+Awareness of climate change: Somewhat aware	Construction	1	total	C0300.02	2955
+Awareness of climate change: Somewhat aware	Wholesale trade	1	total	C0300.02	1491
+Awareness of climate change: Somewhat aware	Machinery & equipment wholesaling	2	total	C0300.02	609
+Awareness of climate change: Somewhat aware	Other wholesale trade	2	total	C0300.02	879
+Awareness of climate change: Somewhat aware	Retail trade	1	total	C0300.02	2145
+Awareness of climate change: Somewhat aware	Accommodation & food services	1	total	C0300.02	3129
+Awareness of climate change: Somewhat aware	"Transport, postal, & warehousing"	1	total	C0300.02	921
+Awareness of climate change: Somewhat aware	Information media & telecommunications	1	total	C0300.02	183
+Awareness of climate change: Somewhat aware	Publishing	2	total	C0300.02	72
+Awareness of climate change: Somewhat aware	Motion picture	2	total	C0300.02	51
+Awareness of climate change: Somewhat aware	Telecommunications	2	total	C0300.02	57
+Awareness of climate change: Somewhat aware	Financial & insurance services	1	total	C0300.02	246
+Awareness of climate change: Somewhat aware	Finance	2	total	C0300.02	90
+Awareness of climate change: Somewhat aware	Insurance	2	total	C0300.02	18
+Awareness of climate change: Somewhat aware	Auxiliary	2	total	C0300.02	141
+Awareness of climate change: Somewhat aware	"Rental, hiring, & real estate services"	1	total	C0300.02	423
+Awareness of climate change: Somewhat aware	"Professional, scientific, & technical services"	1	total	C0300.02	2250
+Awareness of climate change: Somewhat aware	Computer systems design	2	total	C0300.02	423
+Awareness of climate change: Somewhat aware	Other professional scientific	2	total	C0300.02	1833
+Awareness of climate change: Somewhat aware	Administrative & support services	1	total	C0300.02	804
+Awareness of climate change: Somewhat aware	Education & training	1	total	C0300.02	513
+Awareness of climate change: Somewhat aware	Health care & social assistance	1	total	C0300.02	1485
+Awareness of climate change: Somewhat aware	Arts & recreation services	1	total	C0300.02	231
+Awareness of climate change: Somewhat aware	Other services	1	total	C0300.02	678
+Awareness of climate change: Somewhat aware	total	0	total	C0300.02	21417
+Awareness of climate change: Not aware	total	0	619 employees	C0300.03	2955
+Awareness of climate change: Not aware	total	0	2049 employees	C0300.03	519
+Awareness of climate change: Not aware	total	0	5099 employees	C0300.03	105
+Awareness of climate change: Not aware	total	0	100+ employees	C0300.03	42
+Awareness of climate change: Not aware	"Agriculture, forestry, & fishing"	1	total	C0300.03	54

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {  // TODO: Make this test more verbose
             utils::DatabaseFile test_write_db("test/data/new1.dtb");
 
             if (test_read_db.empty()) return 1;
-            if (test_read_db.size() != 100) return 1;  // TODO: Make this automatically update if data source changes
+            if (test_read_db.size() != 99) return 1;  // TODO: Make this automatically update if data source changes
             test_read_db.unload(data);
             test_write_db.load(data);
             if (test_write_db.empty()) return 1;
@@ -53,7 +53,7 @@ int main(int argc, char *argv[]) {  // TODO: Make this test more verbose
             utils::DatabaseFile test_write_db("test/data/new3.dtb", argv[2]);
 
             if (test_read_db.empty()) return 1;
-            if (test_read_db.size() != 100) return 1;  // TODO: Make this automatically update if data source changes
+            if (test_read_db.size() != 99) return 1;  // TODO: Make this automatically update if data source changes
             test_read_db.unload(data);
             test_write_db.load(data);
             if (test_write_db.empty()) return 1;

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
 
         if (argc == 3) {
             utils::DatabaseFile test_read_db(argv[1], argv[2]);
-            utils::DatabaseFile test_write_db("test/data/new2.dtb", argv[2]);
+            utils::DatabaseFile test_write_db("test/data/new3.dtb", argv[2]);
 
             if (test_read_db.empty()) return 1;
             test_read_db.unload(data);
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
             if (test_write_db.keys() != test_read_db.keys()) return 1;
             if (!test_write_db.write()) return 1;
             if (!test_write_db.write(data)) return 1;
-            if (!test_write_db.write("test/data/new2.dtb", data)) return 1;
+            if (!test_write_db.write("test/data/new3.dtb", data)) return 1;
 
             for (size_t i = 0; i < test_read_db.size(); i++) {
                 for (const std::string& key : test_read_db.keys()) {

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -3,7 +3,7 @@
 #include <map>
 #include "../../../src/utils/io/DatabaseFile.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {  // TODO: Make this test more verbose
     try {
         if (argc == 1) {
             utils::DatabaseFile test_db;

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -29,6 +29,7 @@ int main(int argc, char *argv[]) {
             utils::DatabaseFile test_write_db("test/data/new1.dtb");
 
             if (test_read_db.empty()) return 1;
+            if (test_read_db.size() != 100) return 1;  // TODO: Make this automatically update if data source changes
             test_read_db.unload(data);
             test_write_db.load(data);
             if (test_write_db.empty()) return 1;
@@ -52,6 +53,7 @@ int main(int argc, char *argv[]) {
             utils::DatabaseFile test_write_db("test/data/new3.dtb", argv[2]);
 
             if (test_read_db.empty()) return 1;
+            if (test_read_db.size() != 100) return 1;  // TODO: Make this automatically update if data source changes
             test_read_db.unload(data);
             test_write_db.load(data);
             if (test_write_db.empty()) return 1;

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
 
         if (argc == 2) {
             utils::DatabaseFile test_read_db(argv[1]);
-            utils::DatabaseFile test_write_db("test/data/new2.dtb");
+            utils::DatabaseFile test_write_db("test/data/new1.dtb");
 
             if (test_read_db.empty()) return 1;
             test_read_db.unload(data);
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
             if (test_write_db.keys() != test_read_db.keys()) return 1;
             if (!test_write_db.write()) return 1;
             if (!test_write_db.write(data)) return 1;
-            if (!test_write_db.write("test/data/new3.dtb", data)) return 1;
+            if (!test_write_db.write("test/data/new4.dtb", data)) return 1;
 
             for (size_t i = 0; i < test_read_db.size(); i++) {
                 for (const std::string& key : test_read_db.keys()) {

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -1,7 +1,26 @@
 #include "../../../src/utils/io/DatabaseFile.h"
 
-int main(int argc, char *argv[]) {
-    utils::DatabaseFile database_file;
+int main() {
+    try {
+        utils::DatabaseFile test_db;
 
-    return 0;
+        if (test_db.get_delim() != ",") return 1;
+        if (test_db.size() != 0) return 1;
+        if (!test_db.empty()) return 1;
+        if (test_db.open()) return 1;
+        if (test_db.open("ThisDoesNotExist.file")) return 1;
+
+        test_db.set_delim("***");
+        if (test_db.get_delim() != "***") return 1;
+        test_db.set_delim(",");
+        if (test_db.get_delim() != ",") return 1;
+
+        if (!test_db.open("data/bos2021ModC.csv")) return 1;
+        if (!test_db.open("data/bos2021ModC.tsv")) return 1;
+        if (!test_db.open("data/bos2021ModC.dat")) return 1;
+
+        return 0;
+    } catch (...) {
+        return 1;
+    }
 }

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -1,0 +1,7 @@
+#include "../../../src/utils/io/DatabaseFile.h"
+
+int main(int argc, char *argv[]) {
+    utils::DatabaseFile database_file;
+
+    return 0;
+}

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
 
         if (argc == 2) {
             utils::DatabaseFile test_read_db(argv[1]);
-            utils::DatabaseFile test_write_db("data/new.dtb");
+            utils::DatabaseFile test_write_db("test/data/new2.dtb");
 
             if (test_read_db.empty()) return 1;
             test_read_db.unload(data);
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
             if (test_write_db.keys() != test_read_db.keys()) return 1;
             if (!test_write_db.write()) return 1;
             if (!test_write_db.write(data)) return 1;
-            if (!test_write_db.write("data/new2.dtb", data)) return 1;
+            if (!test_write_db.write("test/data/new2.dtb", data)) return 1;
 
             for (size_t i = 0; i < test_read_db.size(); i++) {
                 for (const std::string& key : test_read_db.keys()) {
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
 
         if (argc == 3) {
             utils::DatabaseFile test_read_db(argv[1], argv[2]);
-            utils::DatabaseFile test_write_db(argv[1], argv[2]);
+            utils::DatabaseFile test_write_db("test/data/new2.dtb", argv[2]);
 
             if (test_read_db.empty()) return 1;
             test_read_db.unload(data);
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
             if (test_write_db.keys() != test_read_db.keys()) return 1;
             if (!test_write_db.write()) return 1;
             if (!test_write_db.write(data)) return 1;
-            if (!test_write_db.write("data/new2.dtb", data)) return 1;
+            if (!test_write_db.write("test/data/new2.dtb", data)) return 1;
 
             for (size_t i = 0; i < test_read_db.size(); i++) {
                 for (const std::string& key : test_read_db.keys()) {

--- a/test/utils/io/DatabaseFile.test.cpp
+++ b/test/utils/io/DatabaseFile.test.cpp
@@ -1,25 +1,76 @@
+#include <iostream>
+#include <vector>
+#include <map>
 #include "../../../src/utils/io/DatabaseFile.h"
 
-int main() {
+int main(int argc, char *argv[]) {
     try {
-        utils::DatabaseFile test_db;
+        if (argc == 1) {
+            utils::DatabaseFile test_db;
 
-        if (test_db.get_delim() != ",") return 1;
-        if (test_db.size() != 0) return 1;
-        if (!test_db.empty()) return 1;
-        if (test_db.open()) return 1;
-        if (test_db.open("ThisDoesNotExist.file")) return 1;
+            if (test_db.get_delim() != ",") return 1;
+            if (test_db.size() != 0) return 1;
+            if (!test_db.empty()) return 1;
+            if (test_db.open()) return 1;
+            if (test_db.open("ThisDoesNotExist.file")) return 1;
 
-        test_db.set_delim("***");
-        if (test_db.get_delim() != "***") return 1;
-        test_db.set_delim(",");
-        if (test_db.get_delim() != ",") return 1;
+            test_db.set_delim("***");
+            if (test_db.get_delim() != "***") return 1;
+            test_db.set_delim(",");
+            if (test_db.get_delim() != ",") return 1;
 
-        if (!test_db.open("data/bos2021ModC.csv")) return 1;
-        if (!test_db.open("data/bos2021ModC.tsv")) return 1;
-        if (!test_db.open("data/bos2021ModC.dat")) return 1;
+            return 0;
+        }
 
-        return 0;
+        std::vector<std::map<std::string, std::string>> data;
+
+        if (argc == 2) {
+            utils::DatabaseFile test_read_db(argv[1]);
+            utils::DatabaseFile test_write_db("data/new.dtb");
+
+            if (test_read_db.empty()) return 1;
+            test_read_db.unload(data);
+            test_write_db.load(data);
+            if (test_write_db.empty()) return 1;
+            if (test_write_db.size() != test_read_db.size()) return 1;
+            if (test_write_db.keys() != test_read_db.keys()) return 1;
+            if (!test_write_db.write()) return 1;
+            if (!test_write_db.write(data)) return 1;
+            if (!test_write_db.write("data/new2.dtb", data)) return 1;
+
+            for (size_t i = 0; i < test_read_db.size(); i++) {
+                for (const std::string& key : test_read_db.keys()) {
+                    if (data[i][key] != test_write_db[i][key]) return 1;
+                }
+            }
+
+            return 0;
+        }
+
+        if (argc == 3) {
+            utils::DatabaseFile test_read_db(argv[1], argv[2]);
+            utils::DatabaseFile test_write_db(argv[1], argv[2]);
+
+            if (test_read_db.empty()) return 1;
+            test_read_db.unload(data);
+            test_write_db.load(data);
+            if (test_write_db.empty()) return 1;
+            if (test_write_db.size() != test_read_db.size()) return 1;
+            if (test_write_db.keys() != test_read_db.keys()) return 1;
+            if (!test_write_db.write()) return 1;
+            if (!test_write_db.write(data)) return 1;
+            if (!test_write_db.write("data/new2.dtb", data)) return 1;
+
+            for (size_t i = 0; i < test_read_db.size(); i++) {
+                for (const std::string& key : test_read_db.keys()) {
+                    if (data[i][key] != test_write_db[i][key]) return 1;
+                }
+            }
+
+            return 0;
+        }
+
+        return 1;
     } catch (...) {
         return 1;
     }


### PR DESCRIPTION
Utility class for saving a Vector of HashMaps into a delimiter-separated database text file and vice-versa. Uses comma "," as the default delimiter. Saved file always has first line containing keys and subsequent lines containing values. 

## Notes:
- Can skip through blank lines when reading database file.
- Not greedy, e.g. does not discard consecutive delimiters but treats them as empty fields.
- Quoted field always use quote " character.